### PR TITLE
fix: 修正 GitHub 的名称文言

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
 <h1 style="margin-bottom: 50px">GitHub 文件加速</h1>
 <form action="./" method="get" style="padding-bottom: 40px" target="_blank" class="flex" onsubmit="toSubmit(event)">
     <label class="block" style="width: fit-content">
-        <input class="block url" name="q" type="text" placeholder="键入Github文件链接"
+        <input class="block url" name="q" type="text" placeholder="键入 GitHub 文件链接"
                pattern="^((https|http):\/\/)?(github\.com\/.+?\/.+?\/(?:releases|archive|blob|raw|suites)|((?:raw|gist)\.(?:githubusercontent|github)\.com))\/.+$" required>
         <div class="bar"></div>
     </label>


### PR DESCRIPTION
”GitHub“ 的拼写是固定为 ”GitHub“ 的，不应为 ”Github“