### PR TITLE
fix: Correct type annotation error in worker version

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const Config = {
 
 const whiteList = [] // 白名单，路径里面有包含字符的才会通过，e.g. ['/username/']
 
-/** @type {RequestInit} */
+/** @type {ResponseInit} */
 const PREFLIGHT_INIT = {
     status: 204,
     headers: new Headers({


### PR DESCRIPTION
Fixed a type annotation error, changing incorrect `RequestInit` to the correct `ResponseInit`.